### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-  Flask-Multi-Session [![build status](https://travis-ci.org/nbob/flask-multi-session.svg?branch=master)](https://travis-ci.org/nbob/flask-multi-session) [![build status](https://pypip.in/license/Flask-Multi-Session/badge.png)](https://pypi.python.org/pypi/Flask-Multi-Session)
+  Flask-Multi-Session [![build status](https://travis-ci.org/nbob/flask-multi-session.svg?branch=master)](https://travis-ci.org/nbob/flask-multi-session) [![build status](https://img.shields.io/pypi/l/Flask-Multi-Session.svg)](https://pypi.python.org/pypi/Flask-Multi-Session)
 ==============
 
 __Flask-Multi-Session__ provides __Mongo__ session storage for __Flask__ apps. This module allows you to manage user sessions from different devices, thus you can logout user from all devices. __Flask-Multi-Session__ supports python>=3.5.


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20flask-multi-session))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `flask-multi-session`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.